### PR TITLE
Includes Bitcore Type, wrong build on third-party packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@types/bitcore-lib": "0.15.0",
     "babel-cli": "6.26.0",
     "babel-plugin-module-resolver": "3.0.0",
     "bitcore-lib": "0.15.0",
@@ -28,7 +29,6 @@
   },
   "devDependencies": {
     "@po.et/tslint-rules": "1.1.0",
-    "@types/bitcore-lib": "0.15.0",
     "@types/node-fetch": "1.6.8",
     "alsatian": "2.0.0",
     "nyc": "11.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@po.et/poet-js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "dist/babel/src/index.js",
   "types": "dist/babel/src/index.d.ts",


### PR DESCRIPTION
This PR introduces

- Moves to dependencies ```@types/bitcore-lib```
- Updates version package to 1.0.5

This change is necessary for avoiding the build failed in third-party packages.

For example: https://travis-ci.org/poetapp/frost-client