### PR TITLE
Implement isValidClaim

### DIFF
--- a/src/Claim.ts
+++ b/src/Claim.ts
@@ -72,7 +72,5 @@ export function createClaim(privateKey: string, type: ClaimType, attributes: Cla
   }
 }
 
-export function isValidClaim(claim = {}): boolean {
-  if (!isClaim(claim)) return false
-  return isValidSignature(claim) && getClaimId(claim) === claim.id
-}
+export const isValidClaim = (claim = {}): boolean =>
+  !!isClaim(claim) && isValidSignature(claim) && getClaimId(claim) === claim.id

--- a/src/Claim.ts
+++ b/src/Claim.ts
@@ -3,7 +3,7 @@ import * as bitcore from 'bitcore-lib'
 import * as crypto from 'crypto'
 
 import { IllegalArgumentException } from './Exceptions'
-import { Claim, ClaimAttributes, ClaimType } from './Interfaces'
+import { Claim, ClaimAttributes, ClaimType, isClaim } from './Interfaces'
 
 import { Serialization } from './Serialization'
 
@@ -71,4 +71,10 @@ export function createClaim(privateKey: string, type: ClaimType, attributes: Cla
     id,
     signature,
   }
+}
+
+export function isValidClaim(claim = {}): boolean {
+  if (!isClaim(claim)) return false
+  if (!isValidSignature(claim)) return false
+  return getClaimId(claim) === claim.id ? true : false
 }

--- a/src/Claim.ts
+++ b/src/Claim.ts
@@ -4,7 +4,6 @@ import * as crypto from 'crypto'
 
 import { IllegalArgumentException } from './Exceptions'
 import { Claim, ClaimAttributes, ClaimType, isClaim } from './Interfaces'
-
 import { Serialization } from './Serialization'
 
 export function getClaimId(claim: Claim): string {
@@ -75,6 +74,5 @@ export function createClaim(privateKey: string, type: ClaimType, attributes: Cla
 
 export function isValidClaim(claim = {}): boolean {
   if (!isClaim(claim)) return false
-  if (!isValidSignature(claim)) return false
-  return getClaimId(claim) === claim.id ? true : false
+  return isValidSignature(claim) && getClaimId(claim) === claim.id
 }

--- a/test/Claim/IsValidClaim.ts
+++ b/test/Claim/IsValidClaim.ts
@@ -1,0 +1,40 @@
+/* tslint:disable:no-relative-imports */
+import { Expect, Test, TestCase } from 'alsatian'
+
+import { isValidClaim } from 'Claim'
+import { Claim } from 'Interfaces'
+//
+import { TheRaven } from '../Claims'
+
+export class IsValidClaim {
+  @Test('isValidClaim() : Given a valid cliam : should return true')
+  @TestCase(TheRaven)
+  public correctClaim(claim: Claim) {
+    Expect(isValidClaim(claim)).toBe(true)
+  }
+
+  @Test('isValidClaim() : Given an object that is not a claim : should return false')
+  @TestCase()
+  @TestCase({ foo: 'bar' })
+  public notClaimObject(claim: Claim) {
+    Expect(isValidClaim(claim)).toBe(false)
+  }
+
+  @Test('isValidClaim() : Given a claim with an invalid id : should return false')
+  @TestCase({ ...TheRaven, id: '111' })
+  public invalidId(claim: Claim) {
+    Expect(isValidClaim(claim)).toBe(false)
+  }
+
+  @Test('isValidClaim() : Given a claim with an invalid publicKey : should return false')
+  @TestCase({ ...TheRaven, publicKey: '111' })
+  public invalidPublicKey(claim: Claim) {
+    Expect(isValidClaim(claim)).toBe(false)
+  }
+
+  @Test('isValidClaim() : Given a claim with an invalid signature : should return false')
+  @TestCase({ ...TheRaven, signature: '111' })
+  public invalidSignature(claim: Claim) {
+    Expect(isValidClaim(claim)).toBe(false)
+  }
+}

--- a/test/Claim/IsValidClaim.ts
+++ b/test/Claim/IsValidClaim.ts
@@ -3,11 +3,10 @@ import { Expect, Test, TestCase } from 'alsatian'
 
 import { isValidClaim } from 'Claim'
 import { Claim } from 'Interfaces'
-//
 import { TheRaven } from '../Claims'
 
 export class IsValidClaim {
-  @Test('isValidClaim() : Given a valid cliam : should return true')
+  @Test('isValidClaim() : Given a valid claim : should return true')
   @TestCase(TheRaven)
   public correctClaim(claim: Claim) {
     Expect(isValidClaim(claim)).toBe(true)
@@ -16,7 +15,7 @@ export class IsValidClaim {
   @Test('isValidClaim() : Given an object that is not a claim : should return false')
   @TestCase()
   @TestCase({ foo: 'bar' })
-  public notClaimObject(claim: Claim) {
+  public notClaimObject(claim: any) {
     Expect(isValidClaim(claim)).toBe(false)
   }
 


### PR DESCRIPTION
Added isValidClaim: should take a claim and validate the id, publicKey, and signature of the claim.
Adjust testing format to try and answer the 5 Questions Every Unit Test Must Answer.

Fixes #22
