### PR TITLE
Add jsonld signature test issue

### DIFF
--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'riteway'
 import { createClaim, getClaimId, isValidClaim, isValidSignature, signClaim } from './Claim'
 import { Claim, ClaimAttributes, ClaimType, Identity, isClaim, Work } from './Interfaces'
 
-const returnError = (err: Error): string => err.message
+const getErrorMessage = (err: Error): string => err.message
 
 // Generated:
 // const forge = require('node-forge')
@@ -134,7 +134,7 @@ describe('Claim.getClaimId', async (should: any) => {
     assert({
       given: 'a claim id',
       should: 'be equal to the work id',
-      actual: await getClaimId(TheRaven).catch(returnError),
+      actual: await getClaimId(TheRaven).catch(getErrorMessage),
       expected: TheRaven.id,
     })
   }
@@ -149,7 +149,7 @@ describe('Claim.getClaimId', async (should: any) => {
   }
 
   {
-    const claimId = await getClaimId({ ...TheRaven, issuanceDate: '2017-09-13T15:00:00.000Z' }).catch(returnError)
+    const claimId = await getClaimId({ ...TheRaven, issuanceDate: '2017-09-13T15:00:00.000Z' }).catch(getErrorMessage)
 
     assert({
       given: 'a claim with extra dateCreated, the new dateCreated',
@@ -170,8 +170,8 @@ describe('Claim.getClaimId', async (should: any) => {
       name: TheRaven.claim.name,
     })
 
-    const claimId1 = await getClaimId(work1).catch(returnError)
-    const claimId2 = await getClaimId(work2).catch(returnError)
+    const claimId1 = await getClaimId(work1).catch(getErrorMessage)
+    const claimId2 = await getClaimId(work2).catch(getErrorMessage)
 
     assert({
       given: 'two claims with disordered keys',
@@ -194,8 +194,8 @@ describe('Claim.getClaimId', async (should: any) => {
       datePublished: TheRaven.claim.datePublished,
     })
 
-    const claimId1 = await getClaimId(work1).catch(returnError)
-    const claimId2 = await getClaimId(work2).catch(returnError)
+    const claimId1 = await getClaimId(work1).catch(getErrorMessage)
+    const claimId2 = await getClaimId(work2).catch(getErrorMessage)
 
     assert({
       given: 'two claims with keys casing',
@@ -278,13 +278,13 @@ describe('Claim.createClaim', async (should: any) => {
   }
 
   {
-    const claim = await createClaim(Issuer, ClaimType.Work, TheRavenBook.claim).catch(returnError)
+    const claim = await createClaim(Issuer, ClaimType.Work, TheRavenBook.claim).catch(getErrorMessage)
 
     assert({
       given: 'an extended claim without an external context',
       should: 'will return an Error()',
-      actual: claim,
-      expected: new Error('The property "edition" in the input was not defined in the context.').message,
+      actual: getErrorMessage(claim),
+      expected: 'The property "edition" in the input was not defined in the context.',
     })
   }
 })
@@ -299,8 +299,8 @@ describe('Claim.signClaim', async (should: any) => {
       assert({
         given: 'a claim without id',
         should: `throw an error with the message ${expectedMessage}`,
-        actual: await sign({ ...TheRaven, id: '' }).catch(returnError),
-        expected: new Error(expectedMessage).message,
+        actual: await sign({ ...TheRaven, id: '' }).catch(getErrorMessage),
+        expected: expectedMessage,
       })
     }
   }
@@ -312,9 +312,9 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'a claim without id',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await sign({ ...TheRaven, id: 'be81cc75bcf6ca0f1fdd356f460e6ec920ba36ec78bd9e70c4d04a19f8943102' }).catch(
-        returnError
+        getErrorMessage
       ),
-      expected: new Error(expectedMessage).message,
+      expected: expectedMessage,
     })
   }
 
@@ -325,8 +325,8 @@ describe('Claim.signClaim', async (should: any) => {
     assert({
       given: 'a claim with publicKey undefined',
       should: `throw an error with the message ${expectedMessage}`,
-      actual: await invalidSign(TheRaven).catch(returnError),
-      expected: new Error(expectedMessage).message,
+      actual: await invalidSign(TheRaven).catch(getErrorMessage),
+      expected: expectedMessage,
     })
   }
 
@@ -337,8 +337,8 @@ describe('Claim.signClaim', async (should: any) => {
     assert({
       given: 'invalid signing options',
       should: `throw an error with the message ${expectedMessage}`,
-      actual: await invalidSign2({ ...TheRaven }).catch(returnError),
-      expected: new Error(expectedMessage).message,
+      actual: await invalidSign2({ ...TheRaven }).catch(getErrorMessage),
+      expected: expectedMessage,
     })
   }
 })

--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -300,7 +300,7 @@ describe('Claim.signClaim', async (should: any) => {
         given: 'a claim without id',
         should: `throw an error with the message ${expectedMessage}`,
         actual: await sign({ ...TheRaven, id: '' }).catch(returnError),
-        expected: new Error('expectedMessage'),
+        expected: new Error(expectedMessage),
       })
     }
   }
@@ -326,7 +326,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'a claim with publicKey undefined',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign(TheRaven).catch(returnError),
-      expected: new Error('expectedMessage'),
+      expected: new Error(expectedMessage),
     })
   }
 
@@ -338,7 +338,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'invalid signing options',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign2({ ...TheRaven }).catch(returnError),
-      expected: new Error('expectedMessage'),
+      expected: new Error(expectedMessage),
     })
   }
 })

--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -284,7 +284,7 @@ describe('Claim.createClaim', async (should: any) => {
       given: 'an extended claim without an external context',
       should: 'will return an Error()',
       actual: claim,
-      expected: new Error('The property "edition" in the input was not defined in the context.'),
+      expected: new Error('The property "edition" in the input was not defined in the context.').message,
     })
   }
 })

--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'riteway'
 import { createClaim, getClaimId, isValidClaim, isValidSignature, signClaim } from './Claim'
 import { Claim, ClaimAttributes, ClaimType, Identity, isClaim, Work } from './Interfaces'
 
-const returnError = (err: Error): Error => err
+const returnError = (err: Error): string => err.message
 
 // Generated:
 // const forge = require('node-forge')
@@ -300,7 +300,7 @@ describe('Claim.signClaim', async (should: any) => {
         given: 'a claim without id',
         should: `throw an error with the message ${expectedMessage}`,
         actual: await sign({ ...TheRaven, id: '' }).catch(returnError),
-        expected: new Error(expectedMessage),
+        expected: new Error(expectedMessage).message,
       })
     }
   }
@@ -314,7 +314,7 @@ describe('Claim.signClaim', async (should: any) => {
       actual: await sign({ ...TheRaven, id: 'be81cc75bcf6ca0f1fdd356f460e6ec920ba36ec78bd9e70c4d04a19f8943102' }).catch(
         returnError
       ),
-      expected: new Error('expectedMessage'),
+      expected: new Error(expectedMessage).message,
     })
   }
 
@@ -326,7 +326,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'a claim with publicKey undefined',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign(TheRaven).catch(returnError),
-      expected: new Error(expectedMessage),
+      expected: new Error(expectedMessage).message,
     })
   }
 
@@ -338,7 +338,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'invalid signing options',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign2({ ...TheRaven }).catch(returnError),
-      expected: new Error(expectedMessage),
+      expected: new Error(expectedMessage).message,
     })
   }
 })

--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -300,7 +300,7 @@ describe('Claim.signClaim', async (should: any) => {
         given: 'a claim without id',
         should: `throw an error with the message ${expectedMessage}`,
         actual: await sign({ ...TheRaven, id: '' }).catch(returnError),
-        expected: new Error(expectedMessage),
+        expected: new Error('expectedMessage'),
       })
     }
   }
@@ -314,7 +314,7 @@ describe('Claim.signClaim', async (should: any) => {
       actual: await sign({ ...TheRaven, id: 'be81cc75bcf6ca0f1fdd356f460e6ec920ba36ec78bd9e70c4d04a19f8943102' }).catch(
         returnError
       ),
-      expected: new Error(expectedMessage),
+      expected: new Error('expectedMessage'),
     })
   }
 
@@ -326,7 +326,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'a claim with publicKey undefined',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign(TheRaven).catch(returnError),
-      expected: new Error(expectedMessage),
+      expected: new Error('expectedMessage'),
     })
   }
 
@@ -338,7 +338,7 @@ describe('Claim.signClaim', async (should: any) => {
       given: 'invalid signing options',
       should: `throw an error with the message ${expectedMessage}`,
       actual: await invalidSign2({ ...TheRaven }).catch(returnError),
-      expected: new Error(expectedMessage),
+      expected: new Error('expectedMessage'),
     })
   }
 })

--- a/src/Claim.test.ts
+++ b/src/Claim.test.ts
@@ -288,7 +288,7 @@ describe('Claim.createClaim', async (should: any) => {
     assert({
       given: 'an extended claim without an external context',
       should: 'will return an Error()',
-      actual: getErrorMessage(claim),
+      actual: claim,
       expected: 'The property "edition" in the input was not defined in the context.',
     })
   }


### PR DESCRIPTION
[PR Process](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-process) - [PR Review Checklist](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-review-checklist)

### Release

Semantic release is enabled for this repository. Make sure you follow the right commit message convention. 

We're using semantic-release's default — [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).

## Description of Changes
related: #150

@krobi64 the signClaim tests have an issue in the way its check Errors

I noticed that when riteways actual/expected are used to compare 2 Errors, it does not check for equality of the Error messages.

I've adjusted the tests and returnError to show that it's not actually comparing the messages of the tests.

After making this change here is the output of npm run test

```
TAP version 13
# Claim.getClaimId
ok 1 Given a claim id: should be equal to the work id
ok 2 Given a claim with extra id, the new id: should be ignored in the calculation of the id and should be equal to the work id
ok 3 Given a claim with extra dateCreated, the new dateCreated: should be included in the calculation of the id and should be not equal to the work id
ok 4 Given two claims with disordered keys: should have the same claims id
ok 5 Given two claims with keys casing: should NOT have the same claims id
ok 6 Given A work claim: should generate an id for the claim
ok 7 Given an identity claim: should generate an identityClaim for the claim
ok 8 Given an extended work claim WITHOUT proper context: should generate the id without the extra attributes
ok 9 Given an extended work claim WITH proper context: should generate a different id
# Claim.createClaim
error loading sodium bindings: Cannot find module 'sodium-native'
falling back to javascript version.
ok 10 Given the public key of a Claim: should be equal to public key of key
ok 11 Given a claim with an external context: should include all fields in the claim
ok 12 Given an extended claim without an external context: should will return an Error()
# Claim.signClaim
not ok 13 Given a claim without id: should throw an error with the message Cannot sign a claim that has an empty .id field.
  ---
    operator: deepEqual
    expected: 'Cannot sign a claim that has an empty .id field.'
    actual:   'Cannot sign a claim that has an empty .id field'
    at: assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
    stack: |-
      Error: Given a claim without id: should throw an error with the message Cannot sign a claim that has an empty .id field.
          at Test.assert [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at Test.tapeDeepEqual (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:421:10)
          at Test.bound [as same] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
          at riteway_1.describe (/Users/kennethlavender/projects/poet/poet-js/src/Claim.test.ts:299:7)
          at process._tickCallback (internal/process/next_tick.js:68:7)
  ...
ok 14 Given a claim without id: should throw an error with the message Cannot sign a claim whose id has been altered or generated incorrectly.
not ok 15 Given a claim with publicKey undefined: should throw an error with the message Cannot sign a claim with an invalid creator in the signing options.
  ---
    operator: deepEqual
    expected: |-
      'Cannot sign a claim with an invalid creator in the signing options.'
    actual: |-
      '"options.algorithm" must be specified.'
    at: assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
    stack: |-
      Error: Given a claim with publicKey undefined: should throw an error with the message Cannot sign a claim with an invalid creator in the signing options.
          at Test.assert [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at Test.tapeDeepEqual (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:421:10)
          at Test.bound [as same] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
          at riteway_1.describe (/Users/kennethlavender/projects/poet/poet-js/src/Claim.test.ts:325:5)
  ...
not ok 16 Given invalid signing options: should throw an error with the message Cannot sign this claim with the provided privateKey. It doesn't match the claim's public key.
  ---
    operator: deepEqual
    expected: |-
      'Cannot sign this claim with the provided privateKey. It doesn\'t match the claim\'s public key.'
    actual: |-
      '"options.algorithm" must be specified.'
    at: assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
    stack: |-
      Error: Given invalid signing options: should throw an error with the message Cannot sign this claim with the provided privateKey. It doesn't match the claim's public key.
          at Test.assert [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at Test.tapeDeepEqual (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:421:10)
          at Test.bound [as same] (/Users/kennethlavender/projects/poet/poet-js/node_modules/tape/lib/test.js:76:32)
          at assert (/Users/kennethlavender/projects/poet/poet-js/node_modules/riteway/source/riteway.js:9:14)
          at riteway_1.describe (/Users/kennethlavender/projects/poet/poet-js/src/Claim.test.ts:337:5)
  ...
# Claim.isValidSignature
ok 17 Given a claim with a valid signature: should return true
ok 18 Given a claim with an external context: should return true
ok 19 Given a claim with an invalid public key: should return false
# Claim.isClaim
ok 20 Given a valid claim, isClaim: should return true
# Claim.isValidClaim
ok 21 Given an object that is not a claim: should return false
ok 22 Given a claim with an invalid id: should return false
ok 23 Given a claim with an invalid publicKey: should return false
ok 24 Given a claim with an invalid signature: should return false
ok 25 Given a claim with an invalid input: should return false
# Interfaces
ok 26 Given a valid claim: should return true
ok 27 Given an invalid claim, isClaim: should return false
ok 28 Given a valid Identity claim, isClaim: should return true
ok 29 Given a valid Identity claim, isIdentity: should return true
ok 30 Given a valid Work claim, isIdentity: should return false
ok 31 Given a valid claim with a context: should return true
ok 32 Given a claim with an invalid date: should return false
ok 33 Given a claim with an invalid date: should return false
ok 34 Given a claim with an invalid date: should return false
ok 35 Given a claim with an invalid date: should return false

1..35
# tests 35
# pass  32
# fail  3
```

This shows a couple of hidden issues in a couple tests I think.

For those interested, the behavior is the same in tape, the lib riteway is built on, I created a local test project to verify I can publish it if anyone wants it.

https://github.com/ericelliott/riteway/blob/master/source/riteway.js#L9
https://github.com/substack/tape#tdeepequalactual-expected-msg