### PR TITLE
fix timestamp check

### DIFF
--- a/src/VerifiableClaimSigner.test.ts
+++ b/src/VerifiableClaimSigner.test.ts
@@ -316,7 +316,7 @@ describe('VerifiableClaimSigner.isValidSignature - Ed25519', async (assert: any)
     }
 
     assert({
-      given: 'a Signed Verifiable claim with an signature creator',
+      given: 'a Signed Verifiable claim with an invalid signature creator',
       should: 'return false',
       actual: await isValidSignature(badClaim),
       expected: false,

--- a/src/VerifiableClaimSigner.ts
+++ b/src/VerifiableClaimSigner.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:no-relative-imports */
-import * as cuid from 'cuid'
 
 import { IllegalArgumentException } from './Exceptions'
 import { isSignedVerifiableClaim, SignedVerifiableClaim, SigningAlgorithm, VerifiableClaim } from './Interfaces'
@@ -31,7 +30,7 @@ export const getVerifiableClaimSigner = (): VerifiableClaimSigner => {
   jsig.use('jsonld', jsonld)
 
   const isValidSignature = async (claim: SignedVerifiableClaim): Promise<boolean> => {
-    const results: any = await jsig.verify(claim, { checkNonce: cuid.isCuid })
+    const results: any = await jsig.verify(claim, { checkNonce: false, checkTimestamp: false, checkDomain: false })
 
     return results.verified
   }

--- a/src/VerifiableClaimSigner.ts
+++ b/src/VerifiableClaimSigner.ts
@@ -28,9 +28,11 @@ export const getVerifiableClaimSigner = (): VerifiableClaimSigner => {
   jsonld.documentLoader = dataDocumentLoader
   const jsig = JSONLD_SIGS()
   jsig.use('jsonld', jsonld)
+  const checkNonce = (nonce: string, options: any, callback: any) => callback(null, true)
+  const checkDomain = (nonce: string, options: any, callback: any) => callback(null, true)
 
   const isValidSignature = async (claim: SignedVerifiableClaim): Promise<boolean> => {
-    const results: any = await jsig.verify(claim, { checkNonce: false, checkTimestamp: false, checkDomain: false })
+    const results: any = await jsig.verify(claim, { checkNonce, checkDomain, checkTimestamp: false })
 
     return results.verified
   }

--- a/tests/unit/shared.ts
+++ b/tests/unit/shared.ts
@@ -40,20 +40,8 @@ const workContext = {
 }
 
 const ed25519Base58PublicKey = 'JAi9YoyDdgBQLenyVzoXWH4C26wKMzHrjertxVrjLWTe'
-export const testBadPublicKey: string = 'JAi9YoyDdgBQLenyVzoXWH4C26wKMzHrjertxVrjLWT5'
 export const ed25519Base58PrivateKey: string =
   'LWgo1jraJrCB2QT64UVgRemepsNopBF3eJaYMPYVTxpEoFx7sSzCb1QysHeJkH2fnGFgHirgVR35Hz5A1PpXuH6'
-
-export const badRsaPublicPemKey =
-  '-----BEGIN PUBLIC KEY-----\r\n' +
-  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjKaGI9riNPd87dly3nvh\r\n' +
-  '2ISSB2i9MVO02nVsfzD+D1kahe/mQMgwwwobs9ArkurFqs4j3fwbSPlRU7F/dPon\r\n' +
-  'yrQTMgKGN+jyNV4fGRI16lFbPTKkasRpB9fQ2InIHZkIpUyZHwJYMS1xf8zdtM1i\r\n' +
-  'p1Brevhw8w6QtPIhFMgebWJ2LhanjwZhgyhAQtO0FkUgdSegolRcrFf1cEaDVEUc\r\n' +
-  '2kcJVnLpExN1VLpE4Vnby4ZrNA0r5NgmCPMx15Fp/Vw6v8H1w+kSmgHAWzRlmhUH\r\n' +
-  'lKCGtvEnKkpFfoWJcn59HotofR6k4LD/pkrNWtfRQIaup8N15lNyY5Pjxni7RE/q\r\n' +
-  'mQIDAQAZ\r\n' +
-  '-----END PUBLIC KEY-----\r\n'
 
 export const rsaPemPrivateKey =
   '-----BEGIN RSA PRIVATE KEY-----\r\n' +


### PR DESCRIPTION
[PR Process](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-process) - [PR Review Checklist](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-review-checklist)

### Release

Semantic release is enabled for this repository. Make sure you follow the right commit message convention. 

We're using semantic-release's default — [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).

## Description of Changes

<!-- Remove the back-ticks (`) to link one or more issues fixed/resolved by this PR (or delete if not applicable) -->
Fixes #183 

<!-- Describe your changes below in a reasonable amount of detail -->
The default behavior of `jsonld-signatures` is to verify that the signature creation date is within 15 minutes of the verification action. We have use cases where we may run verifications outside that time window, so this disables the timestamp verification.

Also, since other users may create nonces and domains of their own, putting dummy validity checks on these as well. These don't modify how the signature is generated, just functions to validate the nonce, domain, and timestamp values themselves.